### PR TITLE
Top-level links don't need to specify versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,19 +112,19 @@
   ## Specifications
 
   ### Core Schemas
-  <a class=spec href="core/v0.1/">
+  <a class=spec href="core/">
     <span class=name>core</span>
     <span class=tag>
       GraphQL schemas with interoperable metadata
     </span>
   </a>
 
-  Core schemas are standard GraphQL schemas which follow the [core specification](core/v0.1). The [core spec](core/v0.1) provides machinery to reference namespaced, versioned directives which provide specified metadata to schema processors and data cores.
+  Core schemas are standard GraphQL schemas which follow the [core specification](core/). The [core spec](core/) provides machinery to reference namespaced, versioned directives which provide specified metadata to schema processors and data cores.
 
   All other specifications in this library are core-compliant specs, designed to be referenced from core schemas.
 
   ### Joining and Linking
-  <a class=spec href="join/v0.1/">
+  <a class=spec href="join/">
     <span class=name>join</span>
     <span class=tag>
       for joining subgraphs into a supergraph
@@ -141,7 +141,7 @@
 
   <dt id=def-core-schema><h3>core schema, n.</h3></dt>
   <dd markdown>
-  A GraphQL schema document which follows the [core schema specification](/core/v0.1/). Core schemas provide specified metadata to processors and data cores by referencing features.
+  A GraphQL schema document which follows the [core schema specification](/core/). Core schemas provide specified metadata to processors and data cores by referencing features.
   </dd>
 
   <dt id=def-machinery>machinery, n.</dt>


### PR DESCRIPTION
Now that #9 has set up redirects to the "latest" version, we can make the top-level links go to unversioned URLs and only need to update `_redirects` when there's a new latest version instead of all these links.