### PR TITLE
fix styles

### DIFF
--- a/apollo-light.css
+++ b/apollo-light.css
@@ -291,7 +291,7 @@ h2.spec-definition-head, h3.spec-definition-head {
 }
 
 .spec-requirement.recommended {
-  --requirement-color: var(--green-base);
+  --requirement-color: var(--teal-dark);
 }
 
 .spec-requirement.not.recommended {

--- a/apollo-light.css
+++ b/apollo-light.css
@@ -273,7 +273,7 @@ h2.spec-definition-head, h3.spec-definition-head {
   --requirement-color: var(--green-light);
   border-radius: 0.2rem;
   transition: color 115ms, background 115ms;
-  padding: 0 0.1rem;
+  padding: 0 0.1rem 0.2rem 0.1rem;
 }
 
 .spec-requirement:hover {
@@ -295,11 +295,11 @@ h2.spec-definition-head, h3.spec-definition-head {
 }
 
 .spec-requirement.not.recommended {
-  --requirement-color: var(--teal-light);
+  --requirement-color: var(--orange-base);
 }
 
 .spec-requirement.optional {
-  --requirement-color: var(--orange-base);
+  --requirement-color: var(--indigo-base);
 }
 
 .spec-toc a:hover {

--- a/apollo-light.css
+++ b/apollo-light.css
@@ -1,10 +1,9 @@
-@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:ital,wght@0,400;0,700;1,300;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,300;1,700&display=swap');
 
 @import "apollo-colors.css";
 @import "anatomy.css";
 
 :root {
-  font-family: Source Sans Pro,sans-serif;
   --body-font-family: Source Sans Pro,sans-serif;
   background: var(--body-background-color);
   color: var(--body-text-color);


### PR DESCRIPTION
- we tried to change the body font to source sans pro, but we didn't, so it's just the system default. fix that.
- the text of rfc2119 requirements isn't centered within their box. this is noticeable when they are hovered.
- the color choice for SHOULD NOT was light teal which isn't very readable and doesn't exactly scream SHOULD NOT to me. changed it to orange. MAY/OPTIONAL are orange, which also seems off; change those to indigo.