### PR TITLE
Add cache v0.1 spec, with @cacheControl directive

### DIFF
--- a/__index__.md
+++ b/__index__.md
@@ -1,4 +1,5 @@
 
+- **[cache/v0.1](/cache/v0.1)** ([📄 graphql](cache/v0.1/cache-v0.1.graphql))
 - **[core/v0.1](/core/v0.1)** ([📄 graphql](core/v0.1/core-v0.1.graphql))
 - **[core/v0.2](/core/v0.2)** ([📄 graphql](core/v0.2/core-v0.2.graphql))
 - **[federation/v1.0](/federation/v1.0)** ([📄 graphql](federation/v1.0/federation-v1.0.graphql))

--- a/cache/v0.1/cache-v0.1.graphql
+++ b/cache/v0.1/cache-v0.1.graphql
@@ -1,5 +1,59 @@
 """
-Indicates that values of the given type must not be stored in the cache.
-Use this for instance to prevent the caching of error values.
+Possible values for the `@cacheControl` `scope` argument (unused on the client).
 """
-directive @doNotStore on OBJECT
+enum CacheControlScope {
+    PUBLIC
+    PRIVATE
+}
+
+"""
+Configures cache settings for a field or type.
+
+- `maxAge`: The maximum amount of time the field's cached value is valid, in seconds.
+- `inheritMaxAge`: If true, the field inherits the `maxAge` of its parent field. If set to `true`, `maxAge` must not be provided.
+- `scope`: Unused on the client.
+
+When applied to a type, the settings apply to all schema fields that return this type.
+Field-level settings override type-level settings.
+
+For example:
+
+```graphql
+type Query {
+    me: User
+    user(id: ID!): User @cacheControl(maxAge: 5)
+}
+
+type User @cacheControl(maxAge: 10) {
+    id: ID!
+    email: String
+}
+```
+`Query.me` is valid for 10 seconds, and `Query.user` for 5 seconds.
+"""
+directive @cacheControl(
+    maxAge: Int
+    inheritMaxAge: Boolean
+    scope: CacheControlScope
+) on FIELD_DEFINITION | OBJECT | INTERFACE | UNION
+
+"""
+Configures cache settings for a field.
+
+`@cacheControlField` is the same as `@cacheControl` but can be used on type system extensions for services that do not own the schema like
+client services.
+
+For example:
+
+```graphql
+# extend the schema to set a max age on User.email.
+extend type User @cacheControlField(name: "email", maxAge: 20)
+```
+`User.email` is valid for 20 seconds.
+"""
+directive @cacheControlField(
+    name: String!
+    maxAge: Int
+    inheritMaxAge: Boolean
+    scope: CacheControlScope
+) repeatable on OBJECT | INTERFACE

--- a/cache/v0.1/cache-v0.1.graphql
+++ b/cache/v0.1/cache-v0.1.graphql
@@ -1,0 +1,5 @@
+"""
+Indicates that values of the given type must not be stored in the cache.
+Use this for instance to prevent the caching of error values.
+"""
+directive @doNotStore on OBJECT

--- a/cache/v0.1/cache-v0.1.md
+++ b/cache/v0.1/cache-v0.1.md
@@ -13,6 +13,8 @@
 
 This specification provides a list of directives related to caching. 
 
+Some of the definitions directly comes from [Apollo Server](https://www.apollographql.com/docs/apollo-server/performance/caching/).
+
 #! @cacheControl
 
 :::[definition](cache-v0.1.graphql#@cacheControl)

--- a/cache/v0.1/cache-v0.1.md
+++ b/cache/v0.1/cache-v0.1.md
@@ -13,6 +13,10 @@
 
 This specification provides a list of directives related to caching. 
 
-#! @doNotStore
+#! @cacheControl
 
-:::[definition](cache-v0.1.graphql#@doNotStore)
+:::[definition](cache-v0.1.graphql#@cacheControl)
+
+#! @cacheControlField
+
+:::[definition](cache-v0.1.graphql#@cacheControlField)

--- a/cache/v0.1/cache-v0.1.md
+++ b/cache/v0.1/cache-v0.1.md
@@ -1,0 +1,18 @@
+# cache v0.1
+
+<h2>Directives related to caching</h2>
+
+```raw html
+<table class=spec-data>
+  <tr><td>Status</td><td>Release</td>
+  <tr><td>Version</td><td>0.1</td>
+</table>
+<link rel=stylesheet href=https://specs.apollo.dev/apollo-light.css>
+<script type=module async defer src=https://specs.apollo.dev/inject-logo.js></script>
+```
+
+This specification provides a list of directives related to caching. 
+
+#! @doNotStore
+
+:::[definition](cache-v0.1.graphql#@doNotStore)

--- a/index.md
+++ b/index.md
@@ -39,6 +39,11 @@
 
 [nullability v0.2](nullability/v0.2) incubating directives to work with nullability
 
+## cache v0.1
+
+[cache v0.1](cache/v0.1) directives related to caching
+
+
 # All Schemas
 
 All specifications:


### PR DESCRIPTION
With a client-side cache, in most cases, it doesn't make sense to store responses that contain errors. That is the default behavior with the Apollo Kotlin normalized cache, which looks at the presence of GraphQL `errors` in the response.

However when [modelling errors with types in the schema](https://www.apollographql.com/docs/technotes/TN0041-errors-as-data-explained/), skipping the cache can't be done automatically without a way to know that a given type represents an error.

Similarly, it sometimes makes sense to never cache certain sensitive data, e.g. containing password or other user information.

This proposes a new `@doNotStore` directive that can be applied to objects to indicate they must not be stored in the cache:

```graphql
type Mutation {
  checkout(paymentMethod: ID!): CheckoutResponse
}

union CheckoutResponse =
    Order
  | InsufficientStockError
  | InvalidPaymentMethodError

type Order {...}

type InsufficientStockError @doNotStore {...}

type InvalidPaymentMethodError @doNotStore {...}
```

#### Considerations

- The directive could be made applicable to interfaces too, as a convenience to avoid having to apply it to all concrete objects of a type hierarchy. The tradeoff is explicitness vs concision.
- Created a `cache-v0.1` spec for the occasion, since this is not tied specifically to Apollo Kotlin. Other cache related directives (e.g. `@cacheControl`) can land here