### PR TITLE
Add nullability v0.4

### DIFF
--- a/index.md
+++ b/index.md
@@ -35,9 +35,9 @@
 
 [kotlin_labs v0.3](kotlin_labs/v0.3) incubating directives supported by the Apollo Kotlin client
 
-## nullability v0.3
+## nullability v0.4
 
-[nullability v0.3](nullability/v0.3) incubating directives to work with nullability
+[nullability v0.4](nullability/v0.4) incubating directives to work with nullability
 
 # All Schemas
 

--- a/nullability/v0.4/nullability-v0.4.graphql
+++ b/nullability/v0.4/nullability-v0.4.graphql
@@ -30,7 +30,7 @@ type User {
 Passing a negative level or a level greater than the list dimension is an error.
 
 """
-directive @semanticNonNull(levels: [Int] = [0]) on FIELD_DEFINITION
+directive @semanticNonNull(levels: [Int!]! = [0]) on FIELD_DEFINITION
 
 """
 Indicates that a position is semantically non null: it is only null if there is a matching error in the `errors` array.
@@ -62,12 +62,10 @@ Passing a negative level or a level greater than the list dimension is an error.
 
 See `@semanticNonNull`.
 """
-directive @semanticNonNullField(name: String!, levels: [Int] = [0]) repeatable on OBJECT | INTERFACE
+directive @semanticNonNullField(name: String!, levels: [Int!]! = [0]) repeatable on OBJECT | INTERFACE
 
 """
 Indicates how clients should handle errors on a given position.
-
-When used on the schema definition, `@catch` applies to every position that can return an error.
 
 The `levels` argument indicates where to catch errors in case of lists:
 
@@ -91,22 +89,20 @@ Passing a negative level or a level greater than the list dimension is an error.
 
 See `CatchTo` for more details.
 """
-directive @catch(to: CatchTo! = RESULT, levels: [Int] = [0]) on FIELD | FIELD_DEFINITION | SCHEMA
+directive @catch(to: CatchTo! = RESULT, levels: [Int!]! = [0]) on FIELD
 
 """
-Indicates how clients should handle errors on a given position.
+Indicates how clients should handle errors on a given position by default.
 
-`@catchField` is the same as `@catch` but can be used on type system extensions for services
-that do not own the schema like client services:
+The semantics are the same as `@catch` but `@catchByDefault` only applies to positions that
+can contain JSON `null`. Non-null positions are unchanged.
 
-```graphql
-# extend the schema to catch User.email to `RESULT`.
-extend type User @catchField(name: "email", to: RESULT)
-```
-
-See `@catch`.
+When multiple values of `catchTo` are set for a given position:
+* the `@catch` value is used if set.
+* else the `@catchByDefault` value is used if set on the operation/fragment.
+* else the schema `catchByDefault` value is used.
 """
-directive @catchField(to: CatchTo! = RESULT, levels: [Int] = [0]) repeatable on INTERFACE | OBJECT
+directive @catchByDefault(to: CatchTo!) on SCHEMA | QUERY | MUTATION | SUBSCRIPTION | FRAGMENT_DEFINITION
 
 enum CatchTo {
     """
@@ -128,10 +124,3 @@ enum CatchTo {
     """
     THROW
 }
-
-"""
-Never throw on field errors.
-
-This is used for backward compatibility for clients where this was the default behaviour.
-"""
-directive @ignoreErrors on QUERY | MUTATION | SUBSCRIPTION

--- a/nullability/v0.4/nullability-v0.4.graphql
+++ b/nullability/v0.4/nullability-v0.4.graphql
@@ -1,0 +1,137 @@
+"""
+Indicates that a position is semantically non null: it is only null if there is a matching error in the `errors` array.
+In all other cases, the position is non-null.
+
+Tools doing code generation may use this information to generate the position as non-null if field errors are handled out of band:
+
+```graphql
+type User {
+    # email is semantically non-null and can be generated as non-null by error-handling clients.
+    email: String @semanticNonNull
+}
+```
+
+The `levels` argument indicates what levels are semantically non null in case of lists:
+
+```graphql
+type User {
+    # friends is semantically non null
+    friends: [User] @semanticNonNull # same as @semanticNonNull(levels: [0])
+
+    # every friends[k] is semantically non null
+    friends: [User] @semanticNonNull(levels: [1])
+
+    # friends as well as every friends[k] is semantically non null
+    friends: [User] @semanticNonNull(levels: [0, 1])
+}
+```
+
+`levels` are zero indexed.
+Passing a negative level or a level greater than the list dimension is an error.
+
+"""
+directive @semanticNonNull(levels: [Int] = [0]) on FIELD_DEFINITION
+
+"""
+Indicates that a position is semantically non null: it is only null if there is a matching error in the `errors` array.
+In all other cases, the position is non-null.
+
+`@semanticNonNullField` is the same as `@semanticNonNull` but can be used on type system extensions for services
+that do not own the schema like client services:
+
+```graphql
+# extend the schema to make User.email semantically non-null.
+extend type User @semanticNonNullField(name: "email")
+```
+
+The `levels` argument indicates what levels are semantically non null in case of lists:
+
+```graphql
+# friends is semantically non null
+extend type User @semanticNonNullField(name: "friends")  # same as @semanticNonNullField(name: "friends", levels: [0])
+
+# every friends[k] is semantically non null
+extend type User @semanticNonNullField(name: "friends", levels: [1])
+
+# friends as well as every friends[k] is semantically non null
+extend type User @semanticNonNullField(name: "friends", levels: [0, 1])
+```
+
+`levels` are zero indexed.
+Passing a negative level or a level greater than the list dimension is an error.
+
+See `@semanticNonNull`.
+"""
+directive @semanticNonNullField(name: String!, levels: [Int] = [0]) repeatable on OBJECT | INTERFACE
+
+"""
+Indicates how clients should handle errors on a given position.
+
+When used on the schema definition, `@catch` applies to every position that can return an error.
+
+The `levels` argument indicates where to catch errors in case of lists:
+
+```graphql
+{
+    user {
+        # friends catches errors
+        friends @catch { name } # same as @catch(levels: [0])
+
+        # every friends[k] catches errors
+        friends @catch(levels: [0]) { name }
+
+        # friends as well as every friends[k] catches errors
+        friends @catch(levels: [0, 1]) { name }
+    }
+}
+```
+
+`levels` are zero indexed.
+Passing a negative level or a level greater than the list dimension is an error.
+
+See `CatchTo` for more details.
+"""
+directive @catch(to: CatchTo! = RESULT, levels: [Int] = [0]) on FIELD | FIELD_DEFINITION | SCHEMA
+
+"""
+Indicates how clients should handle errors on a given position.
+
+`@catchField` is the same as `@catch` but can be used on type system extensions for services
+that do not own the schema like client services:
+
+```graphql
+# extend the schema to catch User.email to `RESULT`.
+extend type User @catchField(name: "email", to: RESULT)
+```
+
+See `@catch`.
+"""
+directive @catchField(to: CatchTo! = RESULT, levels: [Int] = [0]) repeatable on INTERFACE | OBJECT
+
+enum CatchTo {
+    """
+    Catch the error and map the position to a result type that can contain either
+    a value or an error.
+    """
+    RESULT,
+    """
+    Catch the error and map the position to a nullable type that will be null
+    in the case of error.
+    This does not allow to distinguish between semantic null and error null but
+    can be simpler in some cases.
+    """
+    NULL,
+    """
+    Throw the error.
+    Parent positions can recover using `RESULT` or `NULL`.
+    If no parent position recovers, the parsing stops.
+    """
+    THROW
+}
+
+"""
+Never throw on field errors.
+
+This is used for backward compatibility for clients where this was the default behaviour.
+"""
+directive @ignoreErrors on QUERY | MUTATION | SUBSCRIPTION

--- a/nullability/v0.4/nullability-v0.4.md
+++ b/nullability/v0.4/nullability-v0.4.md
@@ -1,0 +1,39 @@
+# nullability v0.3
+
+<h2>Experimental nullability directives</h2>
+
+```raw html
+<table class=spec-data>
+  <tr><td>Status</td><td>Release</td>
+  <tr><td>Version</td><td>0.3</td>
+</table>
+<link rel=stylesheet href=https://specs.apollo.dev/apollo-light.css>
+<script type=module async defer src=https://specs.apollo.dev/inject-logo.js></script>
+```
+
+This specification provides a list of directives to help dealing with nullability. For more information, see [the nullability working group GitHub repository.](https://github.com/graphql/nullability-wg)
+
+
+#! @semanticNonNull
+
+:::[definition](nullability-v0.3.graphql#@semanticNonNull)
+
+#! @semanticNonNullField
+
+:::[definition](nullability-v0.3.graphql#@semanticNonNullField)
+
+#! @catch
+
+:::[definition](nullability-v0.3.graphql#@catch)
+
+#! @catchField
+
+:::[definition](nullability-v0.3.graphql#@catchField)
+
+#! @ignoreErrors
+
+:::[definition](nullability-v0.3.graphql#@ignoreErrors)
+
+#! CatchTo
+
+:::[definition](nullability-v0.3.graphql#CatchTo)

--- a/nullability/v0.4/nullability-v0.4.md
+++ b/nullability/v0.4/nullability-v0.4.md
@@ -1,11 +1,11 @@
-# nullability v0.3
+# nullability v0.4
 
 <h2>Experimental nullability directives</h2>
 
 ```raw html
 <table class=spec-data>
   <tr><td>Status</td><td>Release</td>
-  <tr><td>Version</td><td>0.3</td>
+  <tr><td>Version</td><td>0.4</td>
 </table>
 <link rel=stylesheet href=https://specs.apollo.dev/apollo-light.css>
 <script type=module async defer src=https://specs.apollo.dev/inject-logo.js></script>
@@ -26,13 +26,9 @@ This specification provides a list of directives to help dealing with nullabilit
 
 :::[definition](nullability-v0.3.graphql#@catch)
 
-#! @catchField
+#! @catchByDefault
 
-:::[definition](nullability-v0.3.graphql#@catchField)
-
-#! @ignoreErrors
-
-:::[definition](nullability-v0.3.graphql#@ignoreErrors)
+:::[definition](nullability-v0.3.graphql#@catchByDefault)
 
 #! CatchTo
 


### PR DESCRIPTION
It simplifies the definitions by removing `@catchField` and `@ignoreErrors` and add `@catchByDefault` on schema, operations and fragments

See https://github.com/apollographql/specs/pull/50/commits/e6477d1316dc1b12dde0d750d11671e979c79c46 for the actual diff. 