### PR TITLE
Add fakes directives

### DIFF
--- a/__index__.md
+++ b/__index__.md
@@ -1,8 +1,10 @@
 
 - **[cache/v0.1](/cache/v0.1)** ([📄 graphql](cache/v0.1/cache-v0.1.graphql))
+- **[cache/v0.2](/cache/v0.2)** ([📄 graphql](cache/v0.2/cache-v0.2.graphql))
 - **[core/v0.1](/core/v0.1)** ([📄 graphql](core/v0.1/core-v0.1.graphql))
 - **[core/v0.2](/core/v0.2)** ([📄 graphql](core/v0.2/core-v0.2.graphql))
 - **[cost/v0.1](/cost/v0.1)** ([📄 graphql](cost/v0.1/cost-v0.1.graphql))
+- **[fakes/v0.0](/fakes/v0.0)** ([📄 graphql](fakes/v0.0/fakes-v0.0.graphql))
 - **[federation/v1.0](/federation/v1.0)** ([📄 graphql](federation/v1.0/federation-v1.0.graphql))
 - **[federation/v2.0](/federation/v2.0)** ([📄 graphql](federation/v2.0/federation-v2.0.graphql))
 - **[federation/v2.1](/federation/v2.1)** ([📄 graphql](federation/v2.1/federation-v2.1.graphql))

--- a/fakes/v0.0/fakes-v0.0.graphql
+++ b/fakes/v0.0/fakes-v0.0.graphql
@@ -1,74 +1,74 @@
 enum Type {
-    zipCode
-    city
-    streetName
-    streetAddress
-    secondaryAddress
-    country
-    countryCode
-    state
-    stateAbbr
-    latitude
-    longitude
+    ZIP_CODE
+    CITY
+    STREET_NAME
+    STREET_ADDRESS
+    SECONDARY_ADDRESS
+    COUNTRY
+    COUNTRY_CODE
+    STATE
+    STATE_ABBR
+    LATITUDE
+    LONGITUDE
 
-    colorName
-    productName
-    money
-    productMaterial
+    COLOR_NAME
+    PRODUCT_NAME
+    MONEY
+    PRODUCT_MATERIAL
 
-    companyName
-    companyCatchPhrase
-    companyBS
+    COMPANY_NAME
+    COMPANY_CATCH_PHRASE
+    COMPANY_BS
 
-    date
-    pastDate
-    futureDate
+    DATE
+    PAST_DATE
+    FUTURE_DATE
 
-    currencyCode
-    currencyName
-    currencySymbol
-    internationalBankAccountNumber
-    bankIdentifierCode
+    CURRENCY_CODE
+    CURRENCY_NAME
+    CURRENCY_SYMBOL
+    INTERNATIONAL_BANK_ACCOUNT_NUMBER
+    BANK_IDENTIFIER_CODE
 
-    hackerAbbreviation
+    HACKER_ABBREVIATION
 
-    imageUrl
-    avatarUrl
-    email
-    url
-    domainName
-    ipv4Address
-    ipv6Address
-    userAgent
-    colorHex
-    macAddress
-    password
-    lorem
+    IMAGE_URL
+    AVATAR_URL
+    EMAIL
+    URL
+    DOMAIN_NAME
+    IPV4_ADDRESS
+    IPV6_ADDRESS
+    USER_AGENT
+    COLOR_HEX
+    MAC_ADDRESS
+    PASSWORD
+    LOREM
 
-    firstName
-    lastName
-    fullName
-    jobTitle
+    FIRST_NAME
+    LAST_NAME
+    FULL_NAME
+    JOB_TITLE
 
-    phoneNumber
+    PHONE_NUMBER
 
-    number
-    uuid
-    word
-    words
-    locale
+    NUMBER
+    UUID
+    WORD
+    WORDS
+    LOCALE
 
-    filename
-    mimeType
-    fileExtension
-    semver
+    FILENAME
+    MIME_TYPE
+    FILE_EXTENSION
+    SEMVER
 }
 
 directive @fake(
     type: Type!
 ) on FIELD_DEFINITION | SCALAR
 
-directive @listSize(level: Int! = 0, min: Int!, max: Int!) repeatable on FIELD_DEFINITION
+directive @fakeList(level: Int! = 0, minSize: Int!, maxSize: Int!) repeatable on FIELD_DEFINITION
 
 scalar Value
 

--- a/fakes/v0.0/fakes-v0.0.graphql
+++ b/fakes/v0.0/fakes-v0.0.graphql
@@ -1,0 +1,75 @@
+enum Type {
+    zipCode
+    city
+    streetName
+    streetAddress
+    secondaryAddress
+    country
+    countryCode
+    state
+    stateAbbr
+    latitude
+    longitude
+
+    colorName
+    productName
+    money
+    productMaterial
+
+    companyName
+    companyCatchPhrase
+    companyBS
+
+    date
+    pastDate
+    futureDate
+
+    currencyCode
+    currencyName
+    currencySymbol
+    internationalBankAccountNumber
+    bankIdentifierCode
+
+    hackerAbbreviation
+
+    imageUrl
+    avatarUrl
+    email
+    url
+    domainName
+    ipv4Address
+    ipv6Address
+    userAgent
+    colorHex
+    macAddress
+    password
+    lorem
+
+    firstName
+    lastName
+    fullName
+    jobTitle
+
+    phoneNumber
+
+    number
+    uuid
+    word
+    words
+    locale
+
+    filename
+    mimeType
+    fileExtension
+    semver
+}
+
+directive @fake(
+    type: Type!
+) on FIELD_DEFINITION | SCALAR
+
+directive @listSize(level: Int! = 0, min: Int!, max: Int!) repeatable on FIELD_DEFINITION
+
+scalar Value
+
+directive @examples(values: [Value]!) on FIELD_DEFINITION | SCALAR

--- a/fakes/v0.0/fakes-v0.0.graphql
+++ b/fakes/v0.0/fakes-v0.0.graphql
@@ -1,4 +1,4 @@
-enum Type {
+enum FakeType {
     ZIP_CODE
     CITY
     STREET_NAME
@@ -65,11 +65,11 @@ enum Type {
 }
 
 directive @fake(
-    type: Type!
+    type: FakeType!
 ) on FIELD_DEFINITION | SCALAR
 
 directive @fakeList(level: Int! = 0, minSize: Int!, maxSize: Int!) repeatable on FIELD_DEFINITION
 
-scalar Value
+scalar FakeValue
 
-directive @examples(values: [Value]!) on FIELD_DEFINITION | SCALAR
+directive @fakeExamples(values: [FakeValue]!) on FIELD_DEFINITION | SCALAR

--- a/fakes/v0.0/fakes-v0.0.md
+++ b/fakes/v0.0/fakes-v0.0.md
@@ -17,14 +17,14 @@ This specification provides a list of directives to help dealing with fakes.
 
 :::[definition](fakes-v0.0.graphql#@fake)
 
-#! @Type
+#! FakeType
 
-:::[definition](fakes-v0.0.graphql#Type)
+:::[definition](fakes-v0.0.graphql#FakeType)
 
-#! @examples
+#! @fakeExamples
 
-:::[definition](fakes-v0.0.graphql#@examples)
+:::[definition](fakes-v0.0.graphql#@fakeExamples)
 
-#! @listSize
+#! @fakeList
 
-:::[definition](fakes-v0.0.graphql#@listSize)
+:::[definition](fakes-v0.0.graphql#@fakeList)

--- a/fakes/v0.0/fakes-v0.0.md
+++ b/fakes/v0.0/fakes-v0.0.md
@@ -1,0 +1,30 @@
+# fakes v0.0
+
+<h2>Fake your GraphQL data</h2>
+
+```raw html
+<table class=spec-data>
+  <tr><td>Status</td><td>Draft</td>
+  <tr><td>Version</td><td>0.0</td>
+</table>
+<link rel=stylesheet href=https://specs.apollo.dev/apollo-light.css>
+<script type=module async defer src=https://specs.apollo.dev/inject-logo.js></script>
+```
+
+This specification provides a list of directives to help dealing with fakes.
+
+#! @fake
+
+:::[definition](fakes-v0.0.graphql#@fake)
+
+#! @Type
+
+:::[definition](fakes-v0.0.graphql#Type)
+
+#! @examples
+
+:::[definition](fakes-v0.0.graphql#@examples)
+
+#! @listSize
+
+:::[definition](fakes-v0.0.graphql#@listSize)

--- a/index.md
+++ b/index.md
@@ -47,6 +47,9 @@
 
 [cache v0.2](cache/v0.2) directives related to caching
 
+## fakes v0.0
+
+[fakes v0.0](fakes/v0.0) fakes your GraphQL data
 
 # All Schemas
 


### PR DESCRIPTION
Strongly inspired by @IvanGoncharov [graphql-faker](https://github.com/graphql-kit/graphql-faker/blob/297af86443267dc1f8ee918fd5c8ba7ec62f1150/src/fake_definition.ts#L20).

It's missing a few types that I didn't find in Java's [datafaker](https://github.com/datafaker-net/datafaker) and also doesn't provide format options yet. I'm a bit undecided whether or not to use `@oneOf` for them and decided to leave them out for now as it's always easier to add than remove.